### PR TITLE
Tesseract problem fixed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdParty/tesseract"]
+	path = 3rdParty/tesseract
+	url = https://github.com/peirick/VS2015_Tesseract/

--- a/RedEyeRemover/RedEyeRemover.vcxproj
+++ b/RedEyeRemover/RedEyeRemover.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{EF8D4E5D-8484-4465-9CAB-E296893D24D5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RedEyeRemover</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -93,6 +93,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -102,12 +103,12 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\liblept;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\leptonica\src;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\wordrec;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\opencl;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\viewer;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\textord;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\neural_networks\runtime;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\dict;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\cutil;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\cube;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\classify;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\ccstruct;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\ccutil;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\ccmain;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\api;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract_3.05\vs2010\port;C:\Program Files\opencv\build\install\include\opencv2;C:\Program Files\opencv\build\install\include\opencv;C:\Program Files\opencv\build\install\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdParty\tesseract\tesseract_3.05\vs2010\port;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\api;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\ccmain;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\ccutil;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\ccstruct;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\classify;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\cube;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\cutil;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\dict;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\neural_networks\runtime;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\textord;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\viewer;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\opencl;$(SolutionDir)3rdParty\tesseract\tesseract_3.05\wordrec;$(SolutionDir)3rdParty\tesseract\leptonica\src;$(SolutionDir)3rdParty\tesseract\liblept;C:\Program Files\opencv\build\install\include\opencv2;C:\Program Files\opencv\build\install\include\opencv;C:\Program Files\opencv\build\install\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\x64\Debug;C:\Users\Jihed Mestiri\Documents\VS2015_Tesseract-master\tesseract\Debug\;C:\Program Files\opencv\build\install\x64\vc15\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>opencv_aruco320d.lib;opencv_bgsegm320d.lib;opencv_bioinspired320d.lib;opencv_calib3d320d.lib;opencv_ccalib320d.lib;opencv_core320d.lib;opencv_datasets320d.lib;opencv_dnn320d.lib;opencv_dpm320d.lib;opencv_face320d.lib;opencv_features2d320d.lib;opencv_flann320d.lib;opencv_fuzzy320d.lib;opencv_hdf320d.lib;opencv_highgui320d.lib;opencv_imgcodecs320d.lib;opencv_imgproc320d.lib;opencv_line_descriptor320d.lib;opencv_ml320d.lib;opencv_objdetect320d.lib;opencv_optflow320d.lib;opencv_phase_unwrapping320d.lib;opencv_photo320d.lib;opencv_plot320d.lib;opencv_reg320d.lib;opencv_rgbd320d.lib;opencv_saliency320d.lib;opencv_shape320d.lib;opencv_stereo320d.lib;opencv_stitching320d.lib;opencv_structured_light320d.lib;opencv_superres320d.lib;opencv_surface_matching320d.lib;opencv_text320d.lib;opencv_tracking320d.lib;opencv_video320d.lib;opencv_videoio320d.lib;opencv_videostab320d.lib;opencv_xfeatures2d320d.lib;opencv_ximgproc320d.lib;opencv_xobjdetect320d.lib;opencv_xphoto320d.lib;libtesseract.lib;giflib.lib;libjpeg.lib;liblept.lib;libpng.l‌​ib;libtiff.lib;li‌​bwe‌​bp.lib;openjpeg.lib;‌​zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)3rdParty\libs\$(PlatformTarget)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>giflib.lib;libjpeg.lib;liblept.lib;libpng.lib;libtesseract.lib;libtiff.lib;libwebp.lib;openjpeg.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ProjectReference>
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>

--- a/RedEyeRemover/redEyeRemover.cpp
+++ b/RedEyeRemover/redEyeRemover.cpp
@@ -1,6 +1,11 @@
 #include <baseapi.h>
 #include <allheaders.h>
 
+#include <cstdlib>
+#include <iostream>
+
+using namespace std;
+
 int main()
 {
 	char *outText;


### PR DESCRIPTION
Please review the changes. 

Absolute pathes replaced by the solution relative.

VS2015_Tesseract added as Git [submodule](https://github.com/blog/2104-working-with-submodules) Check out your sources together with submodules to get all the sources in the proper location.  

I've excluded OpenCv for simplicity. By the way. You've added both `opencv` and `opencv2` headers. It's incorrect. Only one of them should be used. Read more [here](http://answers.opencv.org/question/4397/include-folder-structure-opencv-andor-opencv2/). I prefer C++ headers `opencv2`.

I've changed WindowsTargetPlatformVersion to 10.0.10240.0 because I don't have 10.0.15063.0 installed. You can revert this change during the merge.